### PR TITLE
Add navigation to Log New Workout button

### DIFF
--- a/src/app/dashboard/dashboard-client.tsx
+++ b/src/app/dashboard/dashboard-client.tsx
@@ -114,7 +114,7 @@ export default function DashboardClient({ workouts, selectedDate }: Props) {
                     <p className="text-muted-foreground mb-4">
                       No workouts logged for this date
                     </p>
-                    <Button>Log New Workout</Button>
+                    <Button onClick={() => router.push('/dashboard/workout/new')}>Log New Workout</Button>
                   </div>
                 )}
               </div>


### PR DESCRIPTION
Fixes #6

Added navigation functionality to the "Log New Workout" button on the dashboard page.

### Changes
- Added `onClick` handler to navigate to `/dashboard/workout/new`
- Uses Next.js router.push() for client-side navigation
- Follows routing standards from `/docs/routing.md`

Generated with [Claude Code](https://claude.ai/code)